### PR TITLE
Display the selected feature percentage correctly

### DIFF
--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
@@ -5,7 +5,7 @@
     <label>Percentage</label>
     <select class="percentage" name="percentage">
       <% 101.times do |i| %>
-        <option value="<%= i %>"<%= " selected='selected'" if feature.percentage == i.to_s %>><%= i %>%</option>
+        <option value="<%= i %>"<%= " selected='selected'" if feature.percentage.to_i == i %>><%= i %>%</option>
       <% end %>
     </select>
     <input type="submit" value="Save" />


### PR DESCRIPTION
Since rollout >= 2.1 percentages can be floats:
https://github.com/fetlife/rollout/commit/ac5f55bfd5aea59bf7c4c9cea189cacd49b7d290
so we have to cast the float string to integer to set the right option as selected.